### PR TITLE
mkcert plugins add

### DIFF
--- a/nagorik_seba/package.json
+++ b/nagorik_seba/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "pinia": "^3.0.3",
+    "vite-plugin-mkcert": "^1.17.8",
     "vue": "^3.5.17",
     "vue-router": "^4.5.1"
   },

--- a/nagorik_seba/vite.config.js
+++ b/nagorik_seba/vite.config.js
@@ -3,16 +3,14 @@ import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
+import mkcert from 'vite-plugin-mkcert'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [
-    vue(),
-    vueDevTools(),
-  ],
+  plugins: [vue(), vueDevTools(), mkcert()],
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
 })


### PR DESCRIPTION
## Summary by Sourcery

Enable local HTTPS development by integrating the mkcert plugin into Vite and adding it as a project dependency

Enhancements:
- Add mkcert to the Vite plugin chain to enable HTTPS during development

Build:
- Add vite-plugin-mkcert dependency to package.json